### PR TITLE
Fix A Critical bug in date conversion

### DIFF
--- a/app/src/main/java/com/afkar/sundatepicker/MainActivity.java
+++ b/app/src/main/java/com/afkar/sundatepicker/MainActivity.java
@@ -16,6 +16,7 @@ import com.alirezaafkar.sundatepicker.components.DateItem;
 import com.alirezaafkar.sundatepicker.interfaces.DateSetListener;
 
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.Locale;
 
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
@@ -29,7 +30,7 @@ public class MainActivity extends FragmentActivity implements
     private Button mEnd;
     private Button mStart;
     private CheckBox mDark;
-    private CheckBox mFeature;
+    private CheckBox mFuture;
 
     private Date mEndDate;
     private Date mStartDate;
@@ -52,7 +53,7 @@ public class MainActivity extends FragmentActivity implements
         mEnd = (Button) findViewById(R.id.endDate);
         mStart = (Button) findViewById(R.id.startDate);
         mDark = (CheckBox) findViewById(R.id.darkTheme);
-        mFeature = (CheckBox) findViewById(R.id.future);
+        mFuture = (CheckBox) findViewById(R.id.future);
 
         mEndDate = new Date();
         mStartDate = new Date();
@@ -72,7 +73,7 @@ public class MainActivity extends FragmentActivity implements
                 .Builder()
                 .id(id)
                 .theme(theme)
-                .feature(mFeature.isChecked());
+                .future(mFuture.isChecked());
 
         if (v.getId() == R.id.startDate)
             builder.date(mStartDate.getDay(), mStartDate.getMonth(), mStartDate.getYear());

--- a/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/DatePicker.java
+++ b/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/DatePicker.java
@@ -101,10 +101,10 @@ public class DatePicker extends DialogFragment
         }
 
         /**
-         * @param feature false means max date is today
+         * @param future false means max date is today
          */
-        public Builder feature(boolean feature) {
-            dateItem.setFeatureDisabled(!feature);
+        public Builder future(boolean future) {
+            dateItem.setFutureDisabled(!future);
             return this;
         }
 
@@ -141,7 +141,7 @@ public class DatePicker extends DialogFragment
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        checkFeature();
+        checkFuture();
         mDate.performClick();
     }
 
@@ -162,8 +162,8 @@ public class DatePicker extends DialogFragment
         return view;
     }
 
-    private void checkFeature() {
-        if (!mDateItem.isFeatureDisabled()) {
+    private void checkFuture() {
+        if (!mDateItem.isFutureDisabled()) {
             mDateItem.setMaxMonth(0);
             return;
         }

--- a/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/components/DateItem.java
+++ b/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/components/DateItem.java
@@ -13,7 +13,7 @@ public class DateItem {
     private int maxYear;
     private int minYear;
     private int maxMonth;
-    private boolean featureDisabled;
+    private boolean futureDisabled;
 
     public DateItem() {
         setDate(new JDF());
@@ -71,12 +71,12 @@ public class DateItem {
         this.maxYear = maxYear;
     }
 
-    public boolean isFeatureDisabled() {
-        return featureDisabled;
+    public boolean isFutureDisabled() {
+        return futureDisabled;
     }
 
-    public void setFeatureDisabled(boolean featureDisabled) {
-        this.featureDisabled = featureDisabled;
+    public void setFutureDisabled(boolean futureDisabled) {
+        this.futureDisabled = futureDisabled;
     }
 
     public void setDate(JDF jdf) {
@@ -108,7 +108,7 @@ public class DateItem {
         jdf.setIranianDate(year, month, day);
         Calendar calendar = Calendar.getInstance();
         calendar.set(jdf.getGregorianYear(),
-                jdf.getGregorianMonth(),
+                jdf.getGregorianMonth()-1,
                 jdf.getGregorianDay());
         return calendar;
     }


### PR DESCRIPTION
Fix Calendar problem which shows one month ahead.
the problem was in getCalendar function in Dateitem.
when you are setting the month, the range begin from zero.
so you should minus one to get the current time.

Also fix typo error in feature parameter of DateItem which should be FUTURE and not FEATURE !