### PR TITLE
Update arrays.xml and fix a typo in month names

### DIFF
--- a/sundatepicker/src/main/res/values/arrays.xml
+++ b/sundatepicker/src/main/res/values/arrays.xml
@@ -12,7 +12,7 @@
 
     <string-array name="persian_months">
         <item>فروردین</item>
-        <item>اردبیهشت</item>
+        <item>اردیبهشت</item>
         <item>خرداد</item>
         <item>تیر</item>
         <item>مرداد</item>


### PR DESCRIPTION
Typo in ORDIBEHESHT Month name

It was written اردبیهشت . I Changed it to اردیبهشت .