### PR TITLE
Causing RuntimeException whenever view restored

### DIFF
--- a/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/DatePicker.java
+++ b/sundatepicker/src/main/java/com/alirezaafkar/sundatepicker/DatePicker.java
@@ -39,8 +39,7 @@ public class DatePicker extends DialogFragment
     private String[] mWeekDays;
     private DateSetListener mCallBack;
 
-    @SuppressLint("ValidFragment")
-    DatePicker() {
+    public DatePicker() {
     }
 
     public static class Builder {


### PR DESCRIPTION
I receive many error like this in my Firebase panel:

Caused by android.support.v4.app.Fragment$b: Unable to instantiate fragment com.alirezaafkar.sundatepicker.a: make sure class name exists, is public, and has an empty constructor that is public

as docs mention too it necessary to have public constructor

https://developer.android.com/reference/android/app/Fragment.html
All sub classes of Fragment must include a public no-argument constructor. The framework will often re-instantiate a fragment class when needed, in particular during state restore, and needs to be able to find this constructor to instantiate it. If the no-argument constructor is not available, a run time exception will occur in some cases during state restore.

I know you want to force the user to use your builder pattern but its a must and would cause force close.